### PR TITLE
Update auth.js to show iframe domain on the UI

### DIFF
--- a/fedcm/fedcm-idp-demo/libs/auth.js
+++ b/fedcm/fedcm-idp-demo/libs/auth.js
@@ -332,6 +332,7 @@ router.get("/metadata", (req, res) => {
   return res.json({
     privacy_policy_url: `${RP_ORIGIN}/privacy_policy.html`,
     terms_of_service_url: `${RP_ORIGIN}/terms_of_service.html`,
+    client_is_third_party_to_top_frame_origin: true,
     icons: [
       {
         // Logo icons can be configured depending on the RP (on the client_id)


### PR DESCRIPTION
This returns `true` unconditionally and rely on the browser to ignore the value if not embedded. A follow-up should actually check the `top_frame_origin` from the request and only return `true` if applicable.